### PR TITLE
Make input and output scrollable instead of the page itself

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -1,11 +1,20 @@
+/* Because this is apparently required to set elements to 100% height */
+html, body {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
+
 /* Code to make input and output line up side by side */
 
 #wrapper {
     display: flex;
     justify-content: space-between;
-    width: 100%;
+    width: 99%;
+    margin-left: auto;
+    margin-right: auto;
     min-height: 300px;
-    max-height: 100%;
+    max-height: calc(100% - 100px); /* Fieldset comes out to a total height of just under 80px; Add a 20px buffer for margin purposes */
 }
 
 .panel {
@@ -26,12 +35,14 @@
     -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
     -moz-box-sizing: border-box;    /* Firefox, other Gecko */
     box-sizing: border-box;         /* Opera/IE 8+ */
+    overflow-y: scroll;
 }
 
 #output {
-    min-width: 100%;
+    height: 100%;
     border-width: 1px;
     border-style: solid;
+    overflow-y: scroll;
 }
 
 #input, #output {
@@ -48,6 +59,7 @@
 fieldset {
     margin-right: -8px;
     padding-right: 0px;
+    width: 99%;
 }
 
 /* Fonts */


### PR DESCRIPTION
I hate CSS.

You can now scroll up and down in the input and output boxes without scrolling the entire viewport.