### PR TITLE
Make pen styles play nicely with themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,14 +174,14 @@
         <div class="input-field">
             <label for="pen-color-select">Pen color</label>
             <select id="pen-color-select">
-                <option value="#000000" selected>Black</option>
+                <option value="" selected>Black/Default</option>    <!-- Black ink uses default text color -->
                 <option value="#ff0000">Red</option>
                 <option value="#0000ff">Blue</option>
                 <option value="#00ff00">Green</option>
                 <option value="#ff00ff">Pink</option>
                 <option value="#ff9900">Orange</option>
                 <option value="#00ffff">Cyan</option>
-                <option value="#ffffff">Invisible</option>
+                <option value="" >Invisible</option>                <!-- Invisible ink uses background color -->
                 <option value="#1c1713">Fancy</option>
             </select>
             <i class="fa fa-question-circle has-tooltip" title="affects text color"></i>

--- a/script/settings.js
+++ b/script/settings.js
@@ -40,6 +40,9 @@ $(function() {
             $('.controlgroup .control').css('-o-transition', '');
             $('.controlgroup .control').css('transition', '');
         }, 300);
+
+        // Update fonts the easy way - simulate selecting the current color
+        $('#pen-color-select option:selected').click();
     });
 });
 
@@ -71,14 +74,19 @@ function updateFonts(e) {
         $('#pen-style-select').val('Segoe Script, sans-serif');
         $('#pen-color-select').val('#1c1713');
 
-    } else if(otherSelect.find('option:selected').text() === 'Fancy') { // Switching away from Fancy
+    }
+    else if (otherSelect.find('option:selected').text() === 'Fancy') { // Switching away from Fancy
         // Make the other not Fancy
         otherSelect[0].selectedIndex = 0;
     }
 
-    // Apply the new styling to the output
-    $('#output').css('font-family', $('#pen-style-select').val());
-    $('#output').css('color', $('#pen-color-select').val());
+    if ($('#pen-color-select option:selected').text() === 'Invisible') { // We're switching to invisible ink
+        let newColor = $('#output').css('background-color');
+        setStyle($('#pen-style-select').val(), newColor);
+    }
+    else {
+        setStyle($('#pen-style-select').val(), $('#pen-color-select').val());
+    }
 
     function findOther() {
         if ($('#pen-style-select')[0] === targetSelect[0]) {
@@ -88,5 +96,11 @@ function updateFonts(e) {
             return $('#pen-style-select');
         }
         console.error('Could not deduce `other` in updateFonts');
+    }
+
+    // Apply the new styling to the output
+    function setStyle(style, color) {
+        $('#output').find('*').css('font-family', style);
+        $('#output').find('*').css('color', color);
     }
 }


### PR DESCRIPTION
Fix #62 

- Make black instead remove any text color override
- Make 'invisible' (white antag pen) instead use background color
- Recursively apply color to penetrate (possibly differently-colored) children like headers or tables