### PR TITLE
 Add automated reply templates for BS12 Faxes

### DIFF
--- a/credits.json
+++ b/credits.json
@@ -39,7 +39,8 @@
             "SierraKomodo",
             "ThatOneGuy",
             "YourDaddy117",
-            "Za_Redman"
+            "Za_Redman",
+            "Lorwp"
         ]
     },
     {

--- a/templates/admin/excom_autoreply.txt
+++ b/templates/admin/excom_autoreply.txt
@@ -1,0 +1,13 @@
+[small]Thank you for your Inquiry!
+
+Unfortunately due to a high volume of requests, we cannot get back to you right now. We shall respond to your query in 2-3 business days.
+
+Thank you for your Patience.
+
+Regards,
+
+Expeditionary Command
+Sol Central Government Expeditionary Corps Observatory, Sol
+
+[i][b]This is an automated reply[/b][/i]
+[/small]

--- a/templates/admin/exo_autoreply.txt
+++ b/templates/admin/exo_autoreply.txt
@@ -1,0 +1,14 @@
+[small]Thank you for your Inquiry!
+
+Unfortunately due to a high volume of requests, we cannot get back to you right now. We shall respond to your query in 2-3 business days.
+
+Thank you for your Patience.
+
+Regards,
+Expeditionary Corps Organisation
+New Amsterdam, Luna, Sol
+
+[b]Major Bill's! When you need it moved, Call Bill.[/b]
+
+[i][b]This is an automated reply[/b][/i]
+[/small]

--- a/templates/index.json
+++ b/templates/index.json
@@ -81,6 +81,10 @@
     "Service": {
         "Kosher Certificate": "service/kosher.txt"
     },
+    "Admin": {
+        "EXCOM Automated Reply": "admin/excom_autoreply.txt",
+        "EXO Automated Reply": "admin/exo_autoreply.txt"
+    },
     "CM-SS13": {
         "W-Y Company Fax": "cm/companyfax.txt",
         "High Command Fax": "cm/commandfax.txt"


### PR DESCRIPTION
Intended to be copy-paste into the `send-fax` dialog as a reply to the torch in certain cases.